### PR TITLE
Bwcheng stkn dropper fix

### DIFF
--- a/src/templates/stkn_dropper.rs
+++ b/src/templates/stkn_dropper.rs
@@ -35,7 +35,7 @@ where
     fn init(&mut self) {}
 
     fn run(&mut self) {
-        let mut prev_stkn = false;
+        let mut prev_stkn = true;
         loop {
             let val_deq = self.in_val.dequeue(&self.time);
             match val_deq {


### PR DESCRIPTION
1. Under the current implementation the prev_stkn variable is initially set to false, as a results, if the first fiber in the input stream is empty, the stop token of that fiber will not be dropped
2. example: input = [ "S0", "S0", "S0", 0, "S1", "D"], expected output = [ 0, "S1", "D" ], actual output = [ "S0", 0, "S1", "D" ]
3.  Unit test with the above testcase is added