### PR TITLE
updated the code for rd_scanner and union to handle empty tokens

### DIFF
--- a/src/templates/joiner.rs
+++ b/src/templates/joiner.rs
@@ -403,6 +403,14 @@ where
                             get_crd1 = true;
                             get_crd2 = true;
                         }
+                        (Token::Stop(_), Token::Empty) => {
+                            get_crd1 = false;
+                            get_crd2 = true;
+                        }
+                        (Token::Empty, Token::Stop(_)) => {
+                            get_crd1 = true;
+                            get_crd2 = false;
+                        }
                         _ => (),
                     }
                 }


### PR DESCRIPTION
1. Update the rd_scanner code such that a stop token is inserted after propagating the empty token.
2. Update the unioner code such that it will not get stuck on the empty token forever.
